### PR TITLE
Configure CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every month
+      interval: "monthly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Populate dependency cache
+name: Build and cache
 
 permissions:
   id-token: write
@@ -15,8 +15,8 @@ defaults:
     shell: bash --noprofile --norc -eufo pipefail {0}
 
 jobs:
-  deps:
-    name: Cache dependencies
+  build:
+    name: Build and cache
     runs-on: ubuntu-latest
 
     steps:
@@ -32,3 +32,7 @@ jobs:
       - name: Build dependencies
         run: |
           nix build -L ".#default.vendorEnv"
+
+      - name: Build executable
+        run: |
+          nix build -L

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Populate dependency cache
+
+permissions:
+  id-token: write
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+  pull_request: {}
+
+defaults:
+  run:
+    shell: bash --noprofile --norc -eufo pipefail {0}
+
+jobs:
+  deps:
+    name: Cache dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout repository
+
+      - uses: DeterminateSystems/nix-installer-action@v6
+        name: Setup nix
+
+      - name: Magic nix cache setup
+        uses: DeterminateSystems/magic-nix-cache-action@v2
+
+      - name: Build dependencies
+        run: |
+          nix build -L ".#default.vendorEnv"


### PR DESCRIPTION
This needs to

- [x] Cache nix dependencies
- [x] Build executable
- [ ] Do something with the executable (cache it wth cachix?)
- [ ] Do the same for aarch64

The github cache security model means PR dependency magic caches aren't re-used on main, which should be fine, as there's sharing thanks to gomod2nix? Except I can get stronger guarantees, with nix, so I can configure cachix from approved/my/all PRs?
