### PR TITLE
Reconfigure flake outputs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,8 +3,8 @@
 }:
 
 buildGoApplication {
-  pname = "spanx";
-  version = "0.1";
+  pname = "caddy-extended";
+  version = "v2.7.5";
   pwd = ./.;
   src = ./.;
   modules = ./gomod2nix.toml;

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,9 @@
         callPackage = pkgs.darwin.apple_sdk_11_0.callPackage or pkgs.callPackage;
       in
       {
+        overlays.default = final: prev: {
+          caddy-extended = self.packages.${system}.default;
+        };
         packages.default = callPackage ./. {
           inherit (gomod2nix.legacyPackages.${system}) buildGoApplication;
         };


### PR DESCRIPTION
To call the package `caddy-extended` and introduce an overlay.
